### PR TITLE
Add Signup mismatch test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest',
+  },
+  moduleFileExtensions: ['js', 'jsx'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.0.0",
@@ -14,6 +15,13 @@
     "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
+    "@testing-library/jest-dom": "^6.1.6",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
   }
 }

--- a/tests/Signup.test.jsx
+++ b/tests/Signup.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Signup from '../Signup';
+
+test('shows error when passwords do not match', async () => {
+  render(<Signup />);
+
+  await userEvent.type(screen.getByPlaceholderText(/first name/i), 'John');
+  await userEvent.type(screen.getByPlaceholderText(/last name/i), 'Doe');
+  await userEvent.type(screen.getByPlaceholderText(/email/i), 'john@example.com');
+  await userEvent.type(screen.getByPlaceholderText('Password'), 'password1');
+  await userEvent.type(screen.getByPlaceholderText('Confirm Password'), 'password2');
+
+  await userEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+  expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add test dependencies and jest config
- ignore node_modules
- verify signup shows mismatch error

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3335d33083269ed52bae75193bfb